### PR TITLE
Fix: Make sure inceptionnet can at least start training

### DIFF
--- a/configs/inception.json
+++ b/configs/inception.json
@@ -5,13 +5,13 @@
         80
     ],
     "in_shape": [
-        120,
-        160,
+        299,
+        299,
         1
     ],
     "preprocessing_scale": [
-        144,
-        192
+        299,
+        299
     ],
     "preprocessing_scale_teacher": [
         60,

--- a/python/kinectgestures/transfer.py
+++ b/python/kinectgestures/transfer.py
@@ -147,7 +147,7 @@ def create_model_inception(out_shape, config, in_shape=(120, 160, 1)):
 
     # pre-trained inception feature extraction
     weights = 'imagenet' if config["pretrained"] else None
-    base_model = InceptionResNetV2(weights=weights, include_top=False, input_shape=(120,160,3))
+    base_model = InceptionResNetV2(weights=weights, include_top=False, input_shape=(299, 299, 3))
     plot_model(base_model, to_file='model_inception.png', show_shapes=True, show_layer_names=True)
     # , input_tensor=input_normalized)
     # x = base_model.output
@@ -157,7 +157,7 @@ def create_model_inception(out_shape, config, in_shape=(120, 160, 1)):
     x = features.output
 
     # add MLP on top
-    #x = Flatten()(x)
+    x = Flatten()(x)
     x = Dense(config["num_features"])(x)
     x = Dropout(config["dropout_rate"])(x)
     x = Dense(out_height * out_width)(x)


### PR DESCRIPTION
This Pull Request changes the training and preprocessing parameters to make sure that training inceptionnot can start without error. I did not check the trained model.

Changes explained:
- InceptionNet needs an input of at least (139, 139, 3). Therefore the 120 by 160 was too small. I increased the input to be (299, 299, 3), which is the default input size for this network.
- Attention: Now, the input is scaled to a square, so the aspect ratio might be lost. I have not visualized the result of preprocessing. Best check this yourself. An input with a skewed aspect ratio might not be a problem. But depending on how you want to compare this with different datasets or something, at least be aware.
- With the above changes, the training will still fail, because the output of the network is of the shape (?, 8, 8, 1536). Hence, the `Dense(config["num_features"])(x)` layer produces an output of (?, 8, 8, 384).  (here `config["num_features"` is set to 384). This is a problem, because on the final Reshape, the desired output size does not match. The fix for this is to enable the Flatten() layer again. Now, instead of (?, 8, 8, 1536) we get the flattened shape of (?, 98304) I think, and then the Dense() layer will simply produce an output of (?, 384) which will make the final Reshape work.

Advice for future debugging: 
- use a debugger! I recommend PyCharm. In there you run the script inside the idea (just create a "Run configuration" to start the script with the correct parameters). Then you can step through these lines, and check the `shape` of the tensors, for example `x` in this case, see at the very bottom of the screenshot.

![Screenshot from 2019-06-25 23-26-48](https://user-images.githubusercontent.com/1116784/60136495-8f880e80-97a4-11e9-947e-87aa982c7393.png)

Additional note: I tested this by running the script as follows (or setting up a corresponding Run config in PyCharm)
```
PYTHONPATH=python/:$PYTHONPATH python python/scripts/train.py configs/inception.json
```